### PR TITLE
feat: read weekly special from specials.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,20 @@ phone running LedArt and push it to the LED unit.
 
 ## Weekly cadence
 
-To refresh the special, edit one line in `build_menu.py`:
+To refresh the special, edit `specials.json`:
 
-```python
-special_line = "Your special here"
+```json
+{
+  "line": "Your special here",
+  "date": "2026-05-09"
+}
 ```
 
-Re-run `python build_menu.py` and re-upload via LedArt.
+Re-run `python build_menu.py`. The output filename is auto-derived from
+`date` (`output/menu_<date>_portrait.png`). Upload via LedArt.
+
+If `specials.json` is missing or malformed, the build falls back to a
+hardcoded default — it never breaks.
 
 ## Display target
 
@@ -64,6 +71,7 @@ zones in between.
 
 ```
 build_menu.py               renderer
+specials.json               weekly special — the only file you edit week-to-week
 requirements.txt            Pillow + segno
 assets/
   ts_farms_logo_chalk.png   logo composited into the header
@@ -72,6 +80,7 @@ reference/
   led_unit_ledart_app.jpeg               LedArt pairing flow reference
 output/
   menu_2026-05-02_portrait.png           current render
+docs/adr/                   architectural decision records (locked decisions)
 ```
 
 ## Source content

--- a/build_menu.py
+++ b/build_menu.py
@@ -9,14 +9,29 @@ from PIL import Image, ImageDraw, ImageFont, ImageFilter
 import segno
 import os
 import io
+import json
 import math
 import random
 
 # ---- canvas ----
 W, H = 1080, 1920
 HERE = os.path.dirname(os.path.abspath(__file__))
-OUT = os.path.join(HERE, "output", "menu_2026-05-02_portrait.png")
+SPECIALS_PATH = os.path.join(HERE, "specials.json")
 LOGO_PATH = os.path.join(HERE, "assets", "ts_farms_logo_chalk.png")
+
+# ---- weekly content (data, not code) ----
+DEFAULT_SPECIAL = "First market of the season — say hi at the booth!"
+DEFAULT_DATE = "2026-05-02"
+try:
+    with open(SPECIALS_PATH) as f:
+        _s = json.load(f)
+    SPECIAL_LINE = _s.get("line", DEFAULT_SPECIAL)
+    MARKET_DATE = _s.get("date", DEFAULT_DATE)
+except (FileNotFoundError, json.JSONDecodeError):
+    SPECIAL_LINE = DEFAULT_SPECIAL
+    MARKET_DATE = DEFAULT_DATE
+
+OUT = os.path.join(HERE, "output", f"menu_{MARKET_DATE}_portrait.png")
 
 # ---- palette ----
 BG_DARK = (22, 22, 22)
@@ -142,11 +157,10 @@ draw.text(((W - tagw)//2, title_y + 110), tagline, font=f_tag, fill=INK_DIM)
 TW_Y = 410
 brush_banner(draw, 80, TW_Y, W-160, 72, "THIS WEEK",
              font(F_DISPLAY, 44))
-# placeholder special text — farmer/THE_USER swaps weekly
+# weekly special text loaded from specials.json
 f_special = font(F_BODY_BOLD, 32)
-special_line = "First market of the season — say hi at the booth!"
-sw = text_w(draw, special_line, f_special)
-draw.text((W/2 - sw/2, TW_Y + 84), special_line, font=f_special, fill=INK)
+sw = text_w(draw, SPECIAL_LINE, f_special)
+draw.text((W/2 - sw/2, TW_Y + 84), SPECIAL_LINE, font=f_special, fill=INK)
 
 # ====================================================================
 # BREAKFAST SANDWICHES

--- a/specials.json
+++ b/specials.json
@@ -1,0 +1,5 @@
+{
+  "line": "First market of the season — say hi at the booth!",
+  "date": "2026-05-02",
+  "notes": "Edit this file weekly. Re-run `python build_menu.py` to regenerate output/menu_<date>_portrait.png."
+}


### PR DESCRIPTION
## What changed

The THIS WEEK ribbon text and the market date now live in \`specials.json\` instead of being hardcoded in \`build_menu.py\`. The build reads the JSON; if it's missing or malformed, it falls back to a hardcoded default so the build never breaks. The output filename is auto-derived from the date.

## Why

Refreshing the weekly special should not require editing Python. With this change, the weekly cadence is a one-line text edit + \`python build_menu.py\` — scriptable for automation (e.g., a Tuesday-morning agent that rewrites \`specials.json\` and opens a PR with the regenerated PNG).

Closes #1

## Test plan

- [x] \`python build_menu.py\` produces the expected output PNG
- [x] Output bytes match the previous render (no visual regression — \`specials.json\` carries the previous hardcoded value)
- [x] Output filename is now derived from \`specials.json\` \"date\" field
- [ ] Reviewer: temporarily rename \`specials.json\` and re-run; confirm fallback works

## Risk

Trivial. Single-file dependency with a defensive try/except. Worst case is the special falls back to the default text. Reverting is one revert commit.

## Notes for the reviewer

The output PNG is included in the diff because the per-render output is the artifact users care about. Future iterations may move output/ to artifacts published in releases instead of committed binaries — see #2 for the resolution work that could trigger that move.